### PR TITLE
Problemi con la stampa dei file scaricati

### DIFF
--- a/virtuale-dl.sh
+++ b/virtuale-dl.sh
@@ -23,7 +23,7 @@ show_help(){
 }
 
 urldecode() {
-    print "%b\n" "$(sed 's/+/ /g;s/%\(..\)/\\x\1/g;')";
+    printf "%b\n" "$(sed 's/+/ /g;s/%\(..\)/\\x\1/g;')";
 }
 
 ############### 


### PR DESCRIPTION
Era presente `print` al posto di `printf` quando si stampava il nome del file scaricato, generando continuamente errore: 
```
virtuale-dl.sh: line 26: print: command not found
```
